### PR TITLE
Update float.vim

### DIFF
--- a/autoload/coc/float.vim
+++ b/autoload/coc/float.vim
@@ -306,7 +306,7 @@ function! coc#float#nvim_close_btn(config, winid, border, hlgroup, related) abor
   else
     let bufnr = coc#float#create_buf(0, ['X'])
     noa let winid = nvim_open_win(bufnr, 0, config)
-    let winhl = 'Normal:'.a:hlgroup.',NormalNC:'.a:hlgroup
+    let winhl = 'Normal:'.a:hlgroup.',NormalNC:'.a:hlgroup.',Search:'
     call s:nvim_add_related(winid, a:winid, 'close', winhl, a:related)
   endif
 endfunction

--- a/autoload/coc/float.vim
+++ b/autoload/coc/float.vim
@@ -154,7 +154,7 @@ function! coc#float#create_float_win(winid, bufnr, config) abort
       let config = s:convert_config_nvim(a:config, 0)
       let hlgroup = get(a:config, 'highlight', 'CocFloating')
       let current = getwinvar(a:winid, '&winhl', '')
-      let winhl = coc#util#merge_winhl(current, [['Normal', hlgroup], ['NormalNC', hlgroup], ['FoldColumn', hlgroup]])
+      let winhl = coc#util#merge_winhl(current, [['Normal', hlgroup], ['NormalNC', hlgroup], ['FoldColumn', hlgroup], ['Search', '']])
       if winhl !=# current
         call setwinvar(a:winid, '&winhl', winhl)
       endif


### PR DESCRIPTION
## Why

`Search:` had accidentally removed in this commit:

https://github.com/neoclide/coc.nvim/commit/578d2e348a15d9e0d653f3c4859eb65c74ce9c5e